### PR TITLE
Update max result payload variable type

### DIFF
--- a/result_types.go
+++ b/result_types.go
@@ -2,32 +2,29 @@
 package morpheus
 
 import (
-    _ "fmt"
+	_ "fmt"
 )
 
 // Common response types
 // Common types used in all responses
 // todo: moves these to shared_result_types.go or something
 
-
-
 // StandardResult is a response format for most actions
 type StandardResult struct {
-    Success bool `json:"success"`
-    Message string `json:"msg"`
-    Errors map[string]string `json:"errors"`
+	Success bool              `json:"success"`
+	Message string            `json:"msg"`
+	Errors  map[string]string `json:"errors"`
 }
 
 // StandardErrorResult is a format for request errors eg. http 400, 401, 500
 type StandardErrorResult struct {
-    StandardResult
+	StandardResult
 }
 
 // A standard format for Delete actions
 type DeleteResult struct {
-    StandardResult
+	StandardResult
 }
-
 
 // Common request types
 type GetByIdRequest struct {
@@ -38,15 +35,15 @@ type GetByIdRequest struct {
 // tenantAbbrev is a response format for  describing a list of objects returned.
 // Could maybe replace use of this with Account for this, it can unmarshal just id and name
 type TenantAbbrev struct {
-    ID int64 `json:"id"`
-    Name string `json:"name"`
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
 }
 
 // MetaResult is a response format for  describing a list of objects returned.
 // This is present in most list results.
 type MetaResult struct {
-    Total int64 `json:"total"`
-    Size int64 `json:"size"`
-    Max int64 `json:"max"`
-    Offset int64 `json:"offset"`
+	Total  int64       `json:"total"`
+	Size   int64       `json:"size"`
+	Max    interface{} `json:"max"`
+	Offset int64       `json:"offset"`
 }


### PR DESCRIPTION
This PR updates the type for the max variable in the result return payload from an int to an interface as some response payload include it as an int and some as a string.