### PR TITLE
Add execution request

### DIFF
--- a/execution_request.go
+++ b/execution_request.go
@@ -10,13 +10,8 @@ var (
 	ExecutionRequestPath = "/api/execution-request"
 )
 
-// Execution Request strcutures for use in request and response payloads
-type ExecutionRequest struct {
-	Script string `json:"script"`
-}
-
 // ExeuctionRequestResult structure parses the response from the server when running or retrieving an exeuction request
-type ExecutionRequestResult struct {
+type ExecutionRequest struct {
 	ID            int64    `json:"id"`
 	UniqueID      string   `json:"uniqueId"`
 	ContainerID   int64    `json:"containerId"`
@@ -36,6 +31,10 @@ type ExecutionRequestResult struct {
 	RawData       string   `json:"rawData"`
 }
 
+type ExecutionRequestResult struct {
+	ExecutionRequest ExecutionRequest `json:"executionRequest"`
+}
+
 // Execution Request Methods
 
 func (client *Client) GetExecutionRequest(uniqueID string, req *Request) (*Response, error) {
@@ -50,7 +49,7 @@ func (client *Client) GetExecutionRequest(uniqueID string, req *Request) (*Respo
 func (client *Client) CreateExecutionRequest(req *Request) (*Response, error) {
 	return client.Execute(&Request{
 		Method:      "POST",
-		Path:        fmt.Sprintf("%s", ExecutionRequestPath),
+		Path:        fmt.Sprintf("%s/%s", ExecutionRequestPath, "execute"),
 		QueryParams: req.QueryParams,
 		Body:        req.Body,
 		Result:      &ExecutionRequestResult{},
@@ -59,7 +58,7 @@ func (client *Client) CreateExecutionRequest(req *Request) (*Response, error) {
 
 // helper functions
 
-func (client *Client) ExecuteScriptOnInstance(instance Instance, script string) (*Response, error) {
+func (client *Client) ExecuteScriptOnInstance(instance Instance, script string) (string, error) {
 
 	resp, err := client.CreateExecutionRequest(&Request{
 		QueryParams: map[string]string{
@@ -74,5 +73,7 @@ func (client *Client) ExecuteScriptOnInstance(instance Instance, script string) 
 		fmt.Println("unable to run script on instance ", instance.ID, " due to ", err)
 	}
 
-	return resp, err
+	scriptResult := resp.Result.(ExecutionRequestResult).ExecutionRequest.StdOut
+
+	return scriptResult, err
 }

--- a/execution_request.go
+++ b/execution_request.go
@@ -1,0 +1,78 @@
+package morpheus
+
+import (
+	"fmt"
+	"strconv"
+)
+
+var (
+	// ExecutionRequestPath is the API endpoint for execution requests
+	ExecutionRequestPath = "/api/execution-request"
+)
+
+// Execution Request strcutures for use in request and response payloads
+type ExecutionRequest struct {
+	Script string `json:"script"`
+}
+
+// ExeuctionRequestResult structure parses the response from the server when running or retrieving an exeuction request
+type ExecutionRequestResult struct {
+	ID            int64    `json:"id"`
+	UniqueID      string   `json:"uniqueId"`
+	ContainerID   int64    `json:"containerId"`
+	ServerID      int64    `json:"serverId"`
+	InstanceID    int64    `json:"instanceId"`
+	ResourceID    int64    `json:"resourceId"`
+	AppID         int64    `json:"appId"`
+	StdOut        string   `json:"stdOut"`
+	StdErr        string   `json:"stdErr"`
+	ExitCode      int64    `json:"exitCode"`
+	Status        string   `json:"status"`
+	ExpiresAt     string   `json:"expiresAt"`
+	CreatedById   int64    `json:"createdById"`
+	StatusMessage string   `json:"statusMessage"`
+	ErrorMessage  string   `json:"errorMessage"`
+	Config        struct{} `json:"config"`
+	RawData       string   `json:"rawData"`
+}
+
+// Execution Request Methods
+
+func (client *Client) GetExecutionRequest(uniqueID string, req *Request) (*Response, error) {
+	return client.Execute(&Request{
+		Method:      "GET",
+		Path:        fmt.Sprintf("%s/%s", ExecutionRequestPath, uniqueID),
+		QueryParams: req.QueryParams,
+		Result:      &ExecutionRequestResult{},
+	})
+}
+
+func (client *Client) CreateExecutionRequest(req *Request) (*Response, error) {
+	return client.Execute(&Request{
+		Method:      "POST",
+		Path:        fmt.Sprintf("%s", ExecutionRequestPath),
+		QueryParams: req.QueryParams,
+		Body:        req.Body,
+		Result:      &ExecutionRequestResult{},
+	})
+}
+
+// helper functions
+
+func (client *Client) ExecuteScriptOnInstance(instance Instance, script string) (*Response, error) {
+
+	resp, err := client.CreateExecutionRequest(&Request{
+		QueryParams: map[string]string{
+			"instanceId": strconv.Itoa(int(instance.ID)),
+		},
+		Body: map[string]interface{}{
+			"script": script,
+		},
+	})
+
+	if err != nil {
+		fmt.Println("unable to run script on instance ", instance.ID, " due to ", err)
+	}
+
+	return resp, err
+}

--- a/execution_request.go
+++ b/execution_request.go
@@ -58,7 +58,7 @@ func (client *Client) CreateExecutionRequest(req *Request) (*Response, error) {
 
 // helper functions
 
-func (client *Client) ExecuteScriptOnInstance(instance Instance, script string) (string, error) {
+func (client *Client) ExecuteScriptOnInstance(instance Instance, script string) (stdOut string, stdErr string, err error) {
 
 	resp, err := client.CreateExecutionRequest(&Request{
 		QueryParams: map[string]string{
@@ -73,7 +73,8 @@ func (client *Client) ExecuteScriptOnInstance(instance Instance, script string) 
 		fmt.Println("unable to run script on instance ", instance.ID, " due to ", err)
 	}
 
-	scriptResult := resp.Result.(*ExecutionRequestResult).ExecutionRequest.StdOut
+	stdOut = resp.Result.(*ExecutionRequestResult).ExecutionRequest.StdOut
+	stdErr = resp.Result.(*ExecutionRequestResult).ExecutionRequest.StdErr
 
-	return scriptResult, err
+	return
 }

--- a/execution_request.go
+++ b/execution_request.go
@@ -73,7 +73,7 @@ func (client *Client) ExecuteScriptOnInstance(instance Instance, script string) 
 		fmt.Println("unable to run script on instance ", instance.ID, " due to ", err)
 	}
 
-	scriptResult := resp.Result.(ExecutionRequestResult).ExecutionRequest.StdOut
+	scriptResult := resp.Result.(*ExecutionRequestResult).ExecutionRequest.StdOut
 
 	return scriptResult, err
 }

--- a/execution_request_test.go
+++ b/execution_request_test.go
@@ -1,0 +1,29 @@
+package morpheus_test
+
+import (
+	"testing"
+
+	"github.com/gomorpheus/morpheus-go-sdk"
+)
+
+// not clear how to test the "get" function since it requires a uniqueID and there is no list method
+// func TestGetExecutionRequest(t *testing.T) {
+
+// }
+
+func TestExecuteScriptOnInstance(t *testing.T) {
+	client := getTestClient(t)
+	resp, err := client.ListInstances(&morpheus.Request{})
+	assertResponse(t, resp, err)
+
+	// parse JSON and fetch the first one by ID
+	listInstancesResult := resp.Result.(*morpheus.ListInstancesResult)
+	instancesCount := listInstancesResult.Meta.Total
+	t.Logf("Found %d Instances.", instancesCount)
+
+	if instancesCount != 0 {
+		firstInstance := (*listInstancesResult.Instances)[0]
+		resp, err = client.ExecuteScriptOnInstance(firstInstance, "pwd")
+		assertResponse(t, resp, err)
+	}
+}

--- a/execution_request_test.go
+++ b/execution_request_test.go
@@ -1,6 +1,7 @@
 package morpheus_test
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/gomorpheus/morpheus-go-sdk"
@@ -11,7 +12,7 @@ import (
 
 // }
 
-func TestExecuteScriptOnInstance(t *testing.T) {
+func TestCreateExecutionRequest(t *testing.T) {
 	client := getTestClient(t)
 	resp, err := client.ListInstances(&morpheus.Request{})
 	assertResponse(t, resp, err)
@@ -23,7 +24,14 @@ func TestExecuteScriptOnInstance(t *testing.T) {
 
 	if instancesCount != 0 {
 		firstInstance := (*listInstancesResult.Instances)[0]
-		resp, err = client.ExecuteScriptOnInstance(firstInstance, "pwd")
+		resp, err := client.CreateExecutionRequest(&morpheus.Request{
+			QueryParams: map[string]string{
+				"instanceId": strconv.Itoa(int(firstInstance.ID)),
+			},
+			Body: map[string]interface{}{
+				"script": "pwd",
+			},
+		})
 		assertResponse(t, resp, err)
 	}
 }

--- a/instances.go
+++ b/instances.go
@@ -165,7 +165,7 @@ func (client *Client) ListInstancePlans(req *Request) (*Response, error) {
 	})
 }
 
-// todo: need this api endpoint still, and consolidate to /api/plans perhaps
+//todo: need this api endpoint still, and consolidate to /api/plans perhaps
 func (client *Client) GetInstancePlan(id int64, req *Request) (*Response, error) {
 	return client.Execute(&Request{
 		Method:      "GET",

--- a/instances.go
+++ b/instances.go
@@ -25,6 +25,7 @@ type Instance struct {
 	Labels       []string               `json:"labels"`
 	Version      string                 `json:"instanceVersion"`
 	Status       string                 `json:"status"`
+	Owner        Owner                  `json:"owner"`
 
 	// might want to define types for these too
 	Volumes              *[]map[string]interface{} `json:"volumes"`
@@ -39,6 +40,11 @@ type InstancePlan struct {
 	ID   int64  `json:"id"`
 	Name string `json:"name"`
 	Code string `json:"code"`
+}
+
+type Owner struct {
+	ID       int64  `json:"id"`
+	Username string `json:"username"`
 }
 
 // ListInstancesResult structure parses the list instances response payload
@@ -159,7 +165,7 @@ func (client *Client) ListInstancePlans(req *Request) (*Response, error) {
 	})
 }
 
-//todo: need this api endpoint still, and consolidate to /api/plans perhaps
+// todo: need this api endpoint still, and consolidate to /api/plans perhaps
 func (client *Client) GetInstancePlan(id int64, req *Request) (*Response, error) {
 	return client.Execute(&Request{
 		Method:      "GET",


### PR DESCRIPTION
PR adds support for the execution-request endpoint.

Did my best to follow existing style and program design conventions but happy to make changes s requested.

I also did what I could with the unit tests, but without the ability to get a list of existing execution requests via the API I don't see a great way to test that component, can take another pass at that if needed.