### PR TITLE
Clusters API AddClusterWorker Support

### DIFF
--- a/clusters.go
+++ b/clusters.go
@@ -484,11 +484,22 @@ type CreateClusterResult struct {
 	Cluster *Cluster          `json:"cluster"`
 }
 
+type AddClusterWorkerResult struct {
+	Success bool              `json:"success"`
+	Message string            `json:"msg"`
+	Errors  map[string]string `json:"errors"`
+	Workers *[]ClusterWorker  `json:"workers"`
+}
+
 type UpdateClusterResult struct {
 	CreateClusterResult
 }
 
 type DeleteClusterResult struct {
+	DeleteResult
+}
+
+type DeleteClusterWorkerResult struct {
 	DeleteResult
 }
 
@@ -616,7 +627,7 @@ func (client *Client) DeleteClusterWorker(id int64, workerId int64, req *Request
 		Path:        fmt.Sprintf("%s/%d/servers/%d", ClustersPath, id, workerId),
 		QueryParams: req.QueryParams,
 		Body:        req.Body,
-		Result:      &StandardResult{},
+		Result:      &DeleteClusterWorkerResult{},
 	})
 }
 
@@ -713,6 +724,17 @@ func (client *Client) ListClusterWorkers(id int64, req *Request) (*Response, err
 		QueryParams: req.QueryParams,
 		Body:        req.Body,
 		Result:      &ListClusterWorkersResults{},
+	})
+}
+
+// AddClusterWorker adds a new cluster worker to an existing cluster
+func (client *Client) AddClusterWorker(id int64, req *Request) (*Response, error) {
+	return client.Execute(&Request{
+		Method:      "POST",
+		Path:        fmt.Sprintf("%s/%d/servers", ClustersPath, id),
+		QueryParams: req.QueryParams,
+		Body:        req.Body,
+		Result:      &AddClusterWorkerResult{},
 	})
 }
 

--- a/storage_volumes.go
+++ b/storage_volumes.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 )
 
-var (
-	// StorageVolumesPath is the API endpoint for Storage Volumes
-	StorageVolumesPath = "/api/storage-volumes"
-)
+// StorageVolumesPath is the API endpoint for Storage Volumes
+var StorageVolumesPath = "/api/storage-volumes"
 
 // StorageVolume structures for use in request and response payloads
 type StorageVolume struct {
@@ -49,7 +47,7 @@ type StorageVolume struct {
 		ID   int64  `json:"id"`
 		Name string `json:"name"`
 	} `json:"datastore"`
-	DatastoreId   string `json:"datastoreId"`
+	DatastoreId   int64  `json:"datastoreId"`
 	StorageGroup  string `json:"storageGroup"`
 	Namespace     string `json:"namespace"`
 	StorageServer string `json:"storageServer"`


### PR DESCRIPTION
This adds support for the Clusters AddClusterWorker API endpoint to the client. This is required to support the Terraform provider with Kubernetes cluster worker node count update capabilities.

Also, this fixes the type of storage volume `DatastoreId`: it should be int64.